### PR TITLE
feat: switch to streaming input mode with QueryPool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -123,6 +124,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
       "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -1748,6 +1750,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2115,6 +2118,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3043,6 +3047,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4395,6 +4400,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5034,6 +5040,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5106,6 +5113,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5200,6 +5208,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -16,6 +16,7 @@ import {
   clearHandoffMode,
 } from "../session/manager.js";
 import { buildHelpCard, buildPermissionModeCard } from "./cards.js";
+import { queryPool } from "../session/query-pool.js";
 
 function formatAge(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
@@ -55,12 +56,14 @@ export async function handleCommand(
   switch (cmd) {
     case "/new":
     case "/clear": {
+      await queryPool.remove(conversationId);
       clearSession(conversationId);
       await ctx.sendActivity("New session. Send your next message.");
       return true;
     }
 
     case "/compact": {
+      await queryPool.remove(conversationId);
       clearSession(conversationId);
       await ctx.sendActivity("Session cleared. Context will be managed fresh.");
       return true;
@@ -85,6 +88,7 @@ export async function handleCommand(
         return true;
       }
 
+      await queryPool.remove(conversationId);
       clearSession(conversationId);
       await ctx.sendActivity(
         `Project: \`${getWorkDir(conversationId)}\` (new session)`,
@@ -105,6 +109,13 @@ export async function handleCommand(
 
       const resolved = MODEL_SHORTCUTS[arg.toLowerCase()] ?? arg;
       setModel(conversationId, resolved);
+      // Hot-update model on active query if present
+      const activeQuery = queryPool.get(conversationId);
+      if (activeQuery) {
+        activeQuery.query.setModel(resolved).catch((err) => {
+          console.warn("[CMD] setModel on active query failed:", err);
+        });
+      }
       await ctx.sendActivity(`Model set to \`${resolved}\``);
       return true;
     }

--- a/src/bot/teams-bot.ts
+++ b/src/bot/teams-bot.ts
@@ -27,10 +27,16 @@ import {
 } from "../session/manager.js";
 import {
   runClaude,
+  saveImagesToTmp,
   type ImageInput,
   type ProgressEvent,
   type RunClaudeOptions,
 } from "../claude/agent.js";
+import {
+  queryPool,
+  type ManagedQuery,
+  type TurnHandlers,
+} from "../session/query-pool.js";
 import { formatResponse, splitMessage } from "../claude/formatter.js";
 import {
   resolvePermission,
@@ -232,23 +238,67 @@ export class ClaudeCodeBot extends ActivityHandler {
     // Handle slash commands (only for text-only messages)
     if (!images && (await handleCommand(text, conversationId, ctx))) return;
 
-    // Run session init prompt on new sessions
-    const isNewSession = !getSession(conversationId);
-    if (isNewSession && config.sessionInitPrompt) {
-      console.log("[BOT] Running session init prompt...");
-      const initResult = await runClaude(
-        config.sessionInitPrompt,
-        undefined,
-        getWorkDir(conversationId),
-        getModel(conversationId),
-        getThinkingTokens(conversationId),
-        getPermissionMode(conversationId),
-      );
-      if (initResult.sessionId) {
-        setSession(conversationId, initResult.sessionId);
+    // Prepare image prompt prefix if needed
+    let finalText = text || "What is in this image?";
+    if (images && images.length > 0) {
+      const paths = await saveImagesToTmp(images);
+      const imageRefs = paths.map((p) => `[Uploaded image: ${p}]`).join("\n");
+      finalText = `The user sent the following image(s). Use the Read tool to view them:\n${imageRefs}\n\n${finalText}`;
+    }
+
+    // Acquire or reuse persistent query
+    const permissionMode = getPermissionMode(conversationId);
+    let managed: ManagedQuery;
+    try {
+      managed = queryPool.acquire(conversationId, {
+        workDir: getWorkDir(conversationId),
+        model: getModel(conversationId),
+        thinkingTokens: getThinkingTokens(conversationId),
+        permissionMode,
+        sessionId: getSession(conversationId),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await ctx.sendActivity(friendlyError(msg));
+      return;
+    }
+
+    // Update mutable permission handler for this turn
+    this.updatePermissionHandler(ctx, managed, permissionMode);
+
+    // If Claude is busy, interrupt first
+    if (managed.busy) {
+      try {
+        await managed.query.interrupt();
+        // Explicitly settle the in-flight turn so its promise doesn't hang
+        if (managed.currentTurn) {
+          managed.currentTurn.reject(new Error("Interrupted by new message"));
+          managed.currentTurn = null;
+          managed.busy = false;
+        }
+        await ctx.sendActivity("⏹ Interrupted. Processing your new message...");
+      } catch (err) {
+        console.warn("[BOT] Interrupt failed, removing query:", err);
+        await queryPool.remove(conversationId);
+        // Fallback to single-turn runClaude
+        await this.fallbackRunClaude(ctx, conversationId, finalText, permissionMode);
+        return;
       }
-      if (initResult.error) {
-        console.warn(`[BOT] Session init error: ${initResult.error}`);
+    }
+
+    // Run session init prompt on first query (no existing session)
+    if (!getSession(conversationId) && config.sessionInitPrompt && !managed.sessionId) {
+      console.log("[BOT] Running session init prompt via pool...");
+      try {
+        const initResult = await queryPool.sendMessage(managed, config.sessionInitPrompt, {});
+        if (initResult.sessionId) {
+          setSession(conversationId, initResult.sessionId);
+        }
+        if (initResult.error) {
+          console.warn(`[BOT] Session init error: ${initResult.error}`);
+        }
+      } catch (err) {
+        console.warn("[BOT] Session init error:", err);
       }
     }
 
@@ -257,40 +307,13 @@ export class ClaudeCodeBot extends ActivityHandler {
     const typingLoop = this.startTypingLoop(ctx, typingController.signal);
     const progress = this.createProgressNotifier(ctx);
 
-    // Build runOptions with permission + prompt handlers
-    const permissionMode = getPermissionMode(conversationId);
-    const runOptions: RunClaudeOptions = {};
-
-    // Add prompt request handler
-    runOptions.onPromptRequest = async (info) => {
-      const response = registerPromptRequest(info.requestId);
-      const card = createPromptCard(info.requestId, info.message, info.options);
-      await ctx.sendActivity({
-        attachments: [
-          {
-            contentType: "application/vnd.microsoft.card.adaptive",
-            content: card,
-          },
-        ],
-      });
-      return response;
-    };
-
-    // Add permission handler (unless bypassing)
-    if (permissionMode !== "bypassPermissions") {
-      const sendCard = async (req: {
-        toolName: string;
-        input: Record<string, unknown>;
-        toolUseID: string;
-        decisionReason?: string;
-      }) => {
-        const card = buildPermissionCard(
-          req.toolName,
-          req.input,
-          req.toolUseID,
-          req.decisionReason,
-        );
-        void ctx.sendActivity({
+    // Build turn handlers
+    const turnHandlers: TurnHandlers = {
+      onProgress: progress.onProgress,
+      onPromptRequest: async (info) => {
+        const response = registerPromptRequest(info.requestId);
+        const card = createPromptCard(info.requestId, info.message, info.options);
+        await ctx.sendActivity({
           attachments: [
             {
               contentType: "application/vnd.microsoft.card.adaptive",
@@ -298,26 +321,15 @@ export class ClaudeCodeBot extends ActivityHandler {
             },
           ],
         });
-      };
-      runOptions.canUseTool = createPermissionHandler(sendCard);
-    }
+        return response;
+      },
+    };
 
     try {
-      console.log("[BOT] Calling runClaude...");
-      const result = await runClaude(
-        text || "What is in this image?",
-        getSession(conversationId),
-        getWorkDir(conversationId),
-        getModel(conversationId),
-        getThinkingTokens(conversationId),
-        permissionMode,
-        images,
-        progress.onProgress,
-        runOptions,
-      );
+      console.log("[BOT] Sending message via query pool...");
+      const result = await queryPool.sendMessage(managed, finalText, turnHandlers);
 
-      console.log("[BOT] runClaude completed, stopping typing");
-      // Stop typing
+      console.log("[BOT] Message completed, stopping typing");
       typingController.abort();
       await typingLoop;
 
@@ -335,10 +347,25 @@ export class ClaudeCodeBot extends ActivityHandler {
       await progress.finalize(splitMessage(formatResponse(result)));
       console.log("[BOT] Response sent successfully");
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+
+      // Interrupted turns are expected — the new message handler already took over
+      if (msg.includes("Interrupted by new message") || msg.includes("Superseded by new turn")) {
+        console.log("[BOT] Previous turn interrupted, skipping error display");
+        typingController.abort();
+        await typingLoop;
+        return;
+      }
+
       console.error("[BOT] Error in handleMessage:", err);
       typingController.abort();
       await typingLoop;
-      const msg = err instanceof Error ? err.message : String(err);
+
+      // If the query stream died, remove it so next message creates a fresh one
+      if (msg.includes("Query closed") || msg.includes("Stream error")) {
+        await queryPool.remove(conversationId);
+      }
+
       await progress.finalize([friendlyError(msg)]);
     }
   }
@@ -365,29 +392,72 @@ export class ClaudeCodeBot extends ActivityHandler {
       console.log(`[HANDOFF] Fork: sessionId=${sessionId}, workDir=${workDir}`);
       const prompt = `The user handed off from Terminal to Teams (project: ${workDir ?? "unknown"}). Welcome them and ask what they need help with.`;
 
-      await this.runClaudeAndRespond(ctx, conversationId, prompt, undefined, {
+      // Use fallbackRunClaude for handoff to preserve fork option
+      // (queryPool.sendMessage does not support resume/fork)
+      const permissionMode = getPermissionMode(conversationId);
+      await this.fallbackRunClaude(ctx, conversationId, prompt, permissionMode, {
         resume: "fork",
       });
     }
   }
 
-  private async runClaudeAndRespond(
+  /**
+   * Update the mutable permission handler on a managed query for the current turn context.
+   */
+  private updatePermissionHandler(
+    ctx: TurnContext,
+    managed: ManagedQuery,
+    permissionMode: string | undefined,
+  ): void {
+    if (permissionMode === "bypassPermissions") {
+      managed.canUseToolHandler.current = null;
+      managed.permissionMode.current = "bypassPermissions";
+    } else {
+      const sendCard = async (req: {
+        toolName: string;
+        input: Record<string, unknown>;
+        toolUseID: string;
+        decisionReason?: string;
+      }) => {
+        const card = buildPermissionCard(
+          req.toolName,
+          req.input,
+          req.toolUseID,
+          req.decisionReason,
+        );
+        ctx.sendActivity({
+          attachments: [
+            {
+              contentType: "application/vnd.microsoft.card.adaptive",
+              content: card,
+            },
+          ],
+        }).catch((err) => {
+          console.error("[BOT] Failed to send permission card:", err);
+        });
+      };
+      managed.canUseToolHandler.current = createPermissionHandler(sendCard);
+      managed.permissionMode.current = permissionMode ?? "default";
+    }
+  }
+
+  /**
+   * Fallback to single-turn runClaude when query pool fails.
+   */
+  private async fallbackRunClaude(
     ctx: TurnContext,
     conversationId: string,
     prompt: string,
-    images?: ImageInput[],
-    runOptions?: RunClaudeOptions,
+    permissionMode: string | undefined,
+    extraRunOptions?: RunClaudeOptions,
   ): Promise<void> {
     const typingController = new AbortController();
     const typingLoop = this.startTypingLoop(ctx, typingController.signal);
     const progress = this.createProgressNotifier(ctx);
 
-    // Create permission handler if not bypassing
-    const permissionMode = getPermissionMode(conversationId);
-    const finalRunOptions = { ...runOptions };
-
-    // Add prompt request handler
-    finalRunOptions.onPromptRequest = async (info) => {
+    const runOptions: RunClaudeOptions = { ...extraRunOptions };
+    runOptions.onPromptRequest = async (info) => {
+      const response = registerPromptRequest(info.requestId);
       const card = createPromptCard(info.requestId, info.message, info.options);
       await ctx.sendActivity({
         attachments: [
@@ -397,10 +467,8 @@ export class ClaudeCodeBot extends ActivityHandler {
           },
         ],
       });
-      // Wait for user response
-      return registerPromptRequest(info.requestId);
+      return response;
     };
-
     if (permissionMode !== "bypassPermissions") {
       const sendCard = async (req: {
         toolName: string;
@@ -414,16 +482,18 @@ export class ClaudeCodeBot extends ActivityHandler {
           req.toolUseID,
           req.decisionReason,
         );
-        await ctx.sendActivity({
+        ctx.sendActivity({
           attachments: [
             {
               contentType: "application/vnd.microsoft.card.adaptive",
               content: card,
             },
           ],
+        }).catch((err) => {
+          console.error("[BOT] Failed to send permission card:", err);
         });
       };
-      finalRunOptions.canUseTool = createPermissionHandler(sendCard);
+      runOptions.canUseTool = createPermissionHandler(sendCard);
     }
 
     try {
@@ -434,10 +504,77 @@ export class ClaudeCodeBot extends ActivityHandler {
         getModel(conversationId),
         getThinkingTokens(conversationId),
         permissionMode,
-        images,
+        undefined,
         progress.onProgress,
-        finalRunOptions,
+        runOptions,
       );
+      typingController.abort();
+      await typingLoop;
+
+      if (result.error) {
+        await progress.finalize([friendlyError(result.error)]);
+        return;
+      }
+      if (result.sessionId) {
+        setSession(conversationId, result.sessionId);
+      }
+      await progress.finalize(splitMessage(formatResponse(result)));
+    } catch (err) {
+      typingController.abort();
+      await typingLoop;
+      const msg = err instanceof Error ? err.message : String(err);
+      await progress.finalize([friendlyError(msg)]);
+    }
+  }
+
+  private async runClaudeAndRespond(
+    ctx: TurnContext,
+    conversationId: string,
+    prompt: string,
+    _images?: ImageInput[],
+    runOptions?: RunClaudeOptions,
+  ): Promise<void> {
+    // For handoff, use query pool too
+    const permissionMode = getPermissionMode(conversationId);
+    let managed: ManagedQuery;
+    try {
+      managed = queryPool.acquire(conversationId, {
+        workDir: getWorkDir(conversationId),
+        model: getModel(conversationId),
+        thinkingTokens: getThinkingTokens(conversationId),
+        permissionMode,
+        sessionId: getSession(conversationId),
+      });
+    } catch (err) {
+      // Fallback to single-turn
+      await this.fallbackRunClaude(ctx, conversationId, prompt, permissionMode);
+      return;
+    }
+
+    this.updatePermissionHandler(ctx, managed, permissionMode);
+
+    const typingController = new AbortController();
+    const typingLoop = this.startTypingLoop(ctx, typingController.signal);
+    const progress = this.createProgressNotifier(ctx);
+
+    const turnHandlers: TurnHandlers = {
+      onProgress: progress.onProgress,
+      onPromptRequest: async (info) => {
+        const card = createPromptCard(info.requestId, info.message, info.options);
+        await ctx.sendActivity({
+          attachments: [
+            {
+              contentType: "application/vnd.microsoft.card.adaptive",
+              content: card,
+            },
+          ],
+        });
+        return registerPromptRequest(info.requestId);
+      },
+    };
+
+    try {
+      const result = await queryPool.sendMessage(managed, prompt, turnHandlers);
       typingController.abort();
       await typingLoop;
 

--- a/src/claude/agent.ts
+++ b/src/claude/agent.ts
@@ -69,7 +69,7 @@ const EXT_MAP: Record<string, string> = {
   "image/webp": ".webp",
 };
 
-async function saveImagesToTmp(images: ImageInput[]): Promise<string[]> {
+export async function saveImagesToTmp(images: ImageInput[]): Promise<string[]> {
   const { writeFile, mkdir } = await import("fs/promises");
   const { join } = await import("path");
   const { randomUUID } = await import("crypto");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import express from "express";
 import { ClaudeCodeBot } from "./bot/teams-bot.js";
 import { loadSessions } from "./session/manager.js";
 import { loadConversationRefs, getConversationRef } from "./handoff/store.js";
+import { queryPool } from "./session/query-pool.js";
 
 // Load persisted state
 loadSessions();
@@ -84,3 +85,18 @@ app.listen(config.port, () => {
   console.log(`Bot running on http://localhost:${config.port}/api/messages`);
   console.log(`Working directory: ${config.claudeWorkDir}`);
 });
+
+// Graceful shutdown — close all persistent CLI queries
+async function shutdown(signal: string): Promise<void> {
+  console.log(`[SHUTDOWN] ${signal}, closing ${queryPool.size} query(s)...`);
+  const forceTimeout = setTimeout(() => {
+    console.warn("[SHUTDOWN] Timed out, forcing exit");
+    process.exit(1);
+  }, 5000);
+  forceTimeout.unref();
+  await queryPool.closeAll();
+  clearTimeout(forceTimeout);
+  process.exit(0);
+}
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));

--- a/src/session/async-queue.ts
+++ b/src/session/async-queue.ts
@@ -1,0 +1,43 @@
+/**
+ * A simple async iterable queue. push() enqueues items,
+ * for-await-of consumes them. end() signals no more items.
+ */
+export class AsyncQueue<T> implements AsyncIterable<T> {
+  private queue: T[] = [];
+  private waiters: Array<(value: IteratorResult<T>) => void> = [];
+  private done = false;
+
+  push(item: T): void {
+    if (this.done) return;
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ value: item, done: false });
+    } else {
+      this.queue.push(item);
+    }
+  }
+
+  end(): void {
+    this.done = true;
+    for (const w of this.waiters) {
+      w({ value: undefined as never, done: true });
+    }
+    this.waiters.length = 0;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () =>
+        new Promise<IteratorResult<T>>((resolve) => {
+          const item = this.queue.shift();
+          if (item !== undefined) {
+            resolve({ value: item, done: false });
+          } else if (this.done) {
+            resolve({ value: undefined as never, done: true });
+          } else {
+            this.waiters.push(resolve);
+          }
+        }),
+    };
+  }
+}

--- a/src/session/query-pool.ts
+++ b/src/session/query-pool.ts
@@ -1,0 +1,510 @@
+/**
+ * Query pool — manages persistent Query objects per conversation.
+ *
+ * Each conversation gets at most one long-lived CLI subprocess.
+ * Messages are fed via an AsyncQueue (async generator prompt),
+ * and results are routed to per-turn handlers via TurnCollector.
+ */
+
+import {
+  query as createQuery,
+  type CanUseTool as SDKCanUseTool,
+  type Query,
+  type SDKMessage,
+  type SDKUserMessage,
+  type PromptRequestOption,
+} from "@anthropic-ai/claude-agent-sdk";
+import { AsyncQueue } from "./async-queue.js";
+import type {
+  ToolInfo,
+  ClaudeResult,
+  ProgressEvent,
+  PromptRequestInfo,
+} from "../claude/agent.js";
+
+// ---------------------------------------------------------------------------
+// TurnCollector — accumulates stream messages for the current turn
+// ---------------------------------------------------------------------------
+
+export type TurnHandlers = {
+  onProgress?: (event: ProgressEvent) => void;
+  onPromptRequest?: (info: PromptRequestInfo) => Promise<string>;
+};
+
+interface TurnCollector {
+  resolve: (result: ClaudeResult) => void;
+  reject: (err: Error) => void;
+  tools: ToolInfo[];
+  resultText?: string;
+  sessionId?: string;
+  handlers: TurnHandlers;
+}
+
+// ---------------------------------------------------------------------------
+// ManagedQuery
+// ---------------------------------------------------------------------------
+
+export interface ManagedQuery {
+  query: Query;
+  inputQueue: AsyncQueue<SDKUserMessage>;
+  conversationId: string;
+  lastActivityAt: number;
+  busy: boolean;
+  sessionId?: string;
+  /** Currently active turn collector (set while busy) */
+  currentTurn: TurnCollector | null;
+  /** Background stream drainer promise */
+  streamDrainer: Promise<void>;
+  /** Mutable permission mode wrapper */
+  permissionMode: { current: string };
+  /** Mutable canUseTool wrapper — the real handler called inside */
+  canUseToolHandler: {
+    current: SDKCanUseTool | null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stream message routing — shared between pool drainer and sendMessage
+// ---------------------------------------------------------------------------
+
+function routeMessage(
+  message: SDKMessage,
+  managed: ManagedQuery,
+  activeQuery: Query,
+): void {
+  const turn = managed.currentTurn;
+
+  // Capture session ID from init message
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    (message as Record<string, unknown>).type === "system" &&
+    "subtype" in message &&
+    (message as Record<string, unknown>).subtype === "init" &&
+    "session_id" in message
+  ) {
+    const sid = (message as Record<string, unknown>).session_id as string;
+    managed.sessionId = sid;
+    if (turn) turn.sessionId = sid;
+  }
+
+  if (!turn) return;
+
+  // PromptRequest handling (duck-type detection)
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "prompt" in message &&
+    "message" in message &&
+    "options" in message
+  ) {
+    const req = message as {
+      prompt: string;
+      message: string;
+      options: PromptRequestOption[];
+    };
+    if (turn.handlers.onPromptRequest) {
+      // Fire async — response will be sent via streamInput
+      turn.handlers
+        .onPromptRequest({
+          requestId: req.prompt,
+          message: req.message,
+          options: req.options,
+        })
+        .then(async (selected) => {
+          // Send prompt response back via streamInput
+          if (typeof activeQuery.streamInput === "function") {
+            const response = {
+              prompt_response: req.prompt,
+              selected,
+            };
+            async function* stream(): AsyncIterable<SDKUserMessage> {
+              yield response as unknown as SDKUserMessage;
+            }
+            await activeQuery.streamInput(stream());
+          }
+        })
+        .catch((err) =>
+          console.error("[QUERY-POOL] PromptRequest handler error:", err),
+        );
+    }
+  }
+
+  // tool_progress events
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    (message as Record<string, unknown>).type === "tool_progress"
+  ) {
+    const progress = message as Record<string, unknown>;
+    const toolName =
+      (progress.tool_name as string | undefined) ??
+      (progress.tool as string | undefined);
+    if (toolName) {
+      const toolInfo: ToolInfo = { name: toolName };
+      const input = progress.input as Record<string, unknown> | undefined;
+      if (input) {
+        if (typeof input.file_path === "string") toolInfo.file = input.file_path;
+        if (typeof input.command === "string")
+          toolInfo.command = input.command.slice(0, 100);
+        if (typeof input.pattern === "string") toolInfo.pattern = input.pattern;
+      }
+      turn.handlers.onProgress?.({ type: "tool_use", tool: toolInfo });
+    }
+  }
+
+  // Collect tool usage from assistant messages
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    (message as Record<string, unknown>).type === "assistant"
+  ) {
+    const msg = message as Record<string, unknown>;
+    const inner = msg.message as Record<string, unknown> | undefined;
+    const content = inner?.content ?? msg.content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (
+          typeof block === "object" &&
+          block !== null &&
+          "type" in block &&
+          (block as Record<string, unknown>).type === "tool_use"
+        ) {
+          const b = block as Record<string, unknown>;
+          const toolInfo: ToolInfo = {
+            name: (b.name as string) ?? "unknown",
+          };
+          const input = b.input as Record<string, unknown> | undefined;
+          if (input) {
+            if (typeof input.file_path === "string")
+              toolInfo.file = input.file_path;
+            if (typeof input.command === "string")
+              toolInfo.command = input.command.slice(0, 100);
+            if (typeof input.pattern === "string")
+              toolInfo.pattern = input.pattern;
+          }
+          turn.tools.push(toolInfo);
+          turn.handlers.onProgress?.({ type: "tool_use", tool: toolInfo });
+        }
+      }
+    }
+  }
+
+  // Capture final result — resolves the current turn
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "result" in message
+  ) {
+    turn.resultText = (message as Record<string, unknown>).result as string;
+    // Result message means this turn is done
+    turn.resolve({
+      sessionId: turn.sessionId ?? managed.sessionId,
+      result: turn.resultText ?? "",
+      tools: turn.tools,
+    });
+    managed.currentTurn = null;
+    managed.busy = false;
+    managed.lastActivityAt = Date.now();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Create a persistent query with async-generator prompt
+// ---------------------------------------------------------------------------
+
+export interface CreateQueryOptions {
+  workDir?: string;
+  model?: string;
+  thinkingTokens?: number | null;
+  permissionMode?: string;
+  canUseTool?: SDKCanUseTool;
+  sessionId?: string;
+  /** Internal: skip continue on retry after crash */
+  _skipContinue?: boolean;
+}
+
+function createPersistentQuery(
+  managed: ManagedQuery,
+  opts: CreateQueryOptions,
+): void {
+  const inputQueue = new AsyncQueue<SDKUserMessage>();
+
+  async function* inputGenerator(): AsyncGenerator<SDKUserMessage> {
+    for await (const msg of inputQueue) {
+      yield msg;
+    }
+  }
+
+  const options: Record<string, unknown> = {
+    allowedTools: [
+      "Read",
+      "Write",
+      "Edit",
+      "Bash",
+      "Glob",
+      "Grep",
+      "AskUserQuestion",
+    ],
+    permissionMode: opts.permissionMode ?? "default",
+    allowDangerouslySkipPermissions:
+      opts.permissionMode === "bypassPermissions",
+    maxTurns: 50,
+    executable: process.execPath,
+  };
+
+  if (opts.model) options.model = opts.model;
+  if (opts.thinkingTokens !== undefined && opts.thinkingTokens !== null) {
+    options.maxThinkingTokens = opts.thinkingTokens;
+  }
+  if (opts.workDir) {
+    options.cwd = opts.workDir;
+  }
+  // In streaming mode, use `continue` to resume the most recent session
+  // in the working directory. If no previous session exists, CLI starts a new one.
+  // (resume + async generator causes CLI crash, so we use continue instead.)
+  if (!opts._skipContinue) {
+    options.continue = true;
+  }
+
+  // Mutable canUseTool wrapper
+  const canUseToolWrapper: SDKCanUseTool = async (toolName, input, callOpts) => {
+    const handler = managed.canUseToolHandler.current;
+    if (!handler) {
+      // No handler → bypass mode, allow everything
+      return {
+        behavior: "allow" as const,
+        updatedInput: input,
+        toolUseID: callOpts.toolUseID,
+      };
+    }
+    return handler(toolName, input, callOpts);
+  };
+  options.canUseTool = canUseToolWrapper;
+
+  console.log(
+    `[QUERY-POOL] createPersistentQuery: cwd=${(options.cwd as string) ?? "none"}, continue=${!!options.continue}`,
+  );
+
+  const q = createQuery({ prompt: inputGenerator(), options });
+
+  managed.query = q;
+  managed.inputQueue = inputQueue;
+
+  // Start background stream drainer
+  managed.streamDrainer = (async () => {
+    try {
+      for await (const message of q as AsyncIterable<SDKMessage>) {
+        routeMessage(message, managed, q);
+      }
+    } catch (err) {
+      console.error("[QUERY-POOL] Stream error:", err);
+      // If the query crashed and we haven't received any session init,
+      // retry without continue (fresh session).
+      if (options.continue && !managed.sessionId) {
+        console.warn("[QUERY-POOL] continue failed, retrying with fresh session");
+        const retryOpts = { ...opts, sessionId: undefined };
+        retryOpts._skipContinue = true;
+        createPersistentQuery(managed, retryOpts);
+        return;
+      }
+      // If a turn is active, reject it
+      if (managed.currentTurn) {
+        managed.currentTurn.reject(
+          err instanceof Error ? err : new Error(String(err)),
+        );
+        managed.currentTurn = null;
+        managed.busy = false;
+      }
+    } finally {
+      console.log(
+        `[QUERY-POOL] Stream ended for ${managed.conversationId.slice(0, 12)}`,
+      );
+    }
+  })();
+}
+
+// ---------------------------------------------------------------------------
+// QueryPool
+// ---------------------------------------------------------------------------
+
+const IDLE_SWEEP_INTERVAL_MS = 60_000;
+const IDLE_TIMEOUT_MS = 30 * 60_000;
+const TURN_TIMEOUT_MS = 10 * 60_000; // 10 minutes per turn
+
+class QueryPool {
+  private pool = new Map<string, ManagedQuery>();
+  private sweepTimer: NodeJS.Timeout | null = null;
+
+  constructor() {
+    this.startSweep();
+  }
+
+  get size(): number {
+    return this.pool.size;
+  }
+
+  /**
+   * Get or create a ManagedQuery for the given conversation.
+   * If options change (workDir, model), the existing query is reused
+   * (caller can use query.setModel() etc. for hot updates).
+   */
+  acquire(
+    conversationId: string,
+    opts: CreateQueryOptions,
+  ): ManagedQuery {
+    let managed = this.pool.get(conversationId);
+    if (managed) {
+      managed.lastActivityAt = Date.now();
+      return managed;
+    }
+
+    // Create new managed query
+    managed = {
+      query: null!,
+      inputQueue: null!,
+      conversationId,
+      lastActivityAt: Date.now(),
+      busy: false,
+      sessionId: opts.sessionId,
+      currentTurn: null,
+      streamDrainer: null!,
+      permissionMode: { current: opts.permissionMode ?? "default" },
+      canUseToolHandler: { current: opts.canUseTool ?? null },
+    };
+
+    createPersistentQuery(managed, opts);
+    this.pool.set(conversationId, managed);
+    console.log(
+      `[QUERY-POOL] Created query for ${conversationId.slice(0, 12)} (pool size: ${this.pool.size})`,
+    );
+    return managed;
+  }
+
+  /**
+   * Send a message to a managed query and wait for the result.
+   */
+  async sendMessage(
+    managed: ManagedQuery,
+    text: string,
+    handlers: TurnHandlers,
+  ): Promise<ClaudeResult> {
+    // Guard: reject any existing in-flight turn to prevent orphaned promises
+    if (managed.busy && managed.currentTurn) {
+      managed.currentTurn.reject(new Error("Superseded by new turn"));
+      managed.currentTurn = null;
+    }
+
+    managed.busy = true;
+    managed.lastActivityAt = Date.now();
+
+    // Create a turn collector that will accumulate results (with timeout)
+    const resultPromise = new Promise<ClaudeResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        managed.currentTurn = null;
+        managed.busy = false;
+        reject(new Error("Turn timed out"));
+      }, TURN_TIMEOUT_MS);
+
+      managed.currentTurn = {
+        resolve: (result) => { clearTimeout(timeout); resolve(result); },
+        reject: (err) => { clearTimeout(timeout); reject(err); },
+        tools: [],
+        handlers,
+      };
+    });
+
+    // Push user message through the input queue
+    const userMessage: SDKUserMessage = {
+      type: "user",
+      message: { role: "user", content: text },
+      parent_tool_use_id: null,
+      session_id: managed.sessionId ?? "",
+    };
+    managed.inputQueue.push(userMessage);
+
+    try {
+      return await resultPromise;
+    } catch (err) {
+      managed.busy = false;
+      managed.lastActivityAt = Date.now();
+      throw err;
+    }
+  }
+
+  /**
+   * Remove and close a query for a conversation.
+   */
+  async remove(conversationId: string): Promise<void> {
+    const managed = this.pool.get(conversationId);
+    if (!managed) return;
+
+    this.pool.delete(conversationId);
+    console.log(
+      `[QUERY-POOL] Removing query for ${conversationId.slice(0, 12)} (pool size: ${this.pool.size})`,
+    );
+
+    try {
+      managed.inputQueue.end();
+      managed.query.close();
+      // If a turn is active, reject it
+      if (managed.currentTurn) {
+        managed.currentTurn.reject(new Error("Query closed"));
+        managed.currentTurn = null;
+        managed.busy = false;
+      }
+    } catch {
+      // Ignore close errors
+    }
+  }
+
+  /**
+   * Close all queries — used for graceful shutdown.
+   */
+  async closeAll(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+
+    const ids = [...this.pool.keys()];
+    await Promise.allSettled(ids.map((id) => this.remove(id)));
+  }
+
+  /**
+   * Check if a conversation has an active query.
+   */
+  has(conversationId: string): boolean {
+    return this.pool.has(conversationId);
+  }
+
+  /**
+   * Get a managed query without creating one.
+   */
+  get(conversationId: string): ManagedQuery | undefined {
+    return this.pool.get(conversationId);
+  }
+
+  private startSweep(): void {
+    this.sweepTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [id, managed] of this.pool) {
+        if (!managed.busy && now - managed.lastActivityAt > IDLE_TIMEOUT_MS) {
+          console.log(
+            `[QUERY-POOL] Idle sweep: closing ${id.slice(0, 12)}`,
+          );
+          void this.remove(id);
+        }
+      }
+    }, IDLE_SWEEP_INTERVAL_MS);
+
+    // Don't prevent process exit
+    this.sweepTimer.unref();
+  }
+}
+
+// Singleton
+export const queryPool = new QueryPool();

--- a/tests/bot-permission-flow.test.ts
+++ b/tests/bot-permission-flow.test.ts
@@ -15,6 +15,7 @@ import { TestAdapter, ActivityTypes, type Activity } from "botbuilder";
 // ---- Mocks ----
 
 const runClaudeMock = vi.fn();
+const sendMessageMock = vi.fn();
 
 const sessionState = {
   sessionId: undefined as string | undefined,
@@ -30,6 +31,33 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 
 vi.mock("../src/claude/agent.js", () => ({
   runClaude: (...args: unknown[]) => runClaudeMock(...args),
+  saveImagesToTmp: vi.fn(async () => []),
+}));
+
+// Mock the query pool
+const mockManagedQuery = {
+  query: { interrupt: vi.fn(), setModel: vi.fn(), close: vi.fn() },
+  inputQueue: { push: vi.fn(), end: vi.fn() },
+  conversationId: "conv-perm-1",
+  lastActivityAt: Date.now(),
+  busy: false,
+  sessionId: "existing-session" as string | undefined,
+  currentTurn: null,
+  streamDrainer: Promise.resolve(),
+  permissionMode: { current: "default" },
+  canUseToolHandler: { current: null as unknown },
+};
+
+vi.mock("../src/session/query-pool.js", () => ({
+  queryPool: {
+    acquire: vi.fn(() => mockManagedQuery),
+    sendMessage: (...args: unknown[]) => sendMessageMock(...args),
+    remove: vi.fn(async () => {}),
+    closeAll: vi.fn(async () => {}),
+    has: vi.fn(() => false),
+    get: vi.fn(() => undefined),
+    size: 0,
+  },
 }));
 
 vi.mock("../src/handoff/store.js", () => ({
@@ -85,6 +113,10 @@ describe("handleMessage passes permission + prompt handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     runClaudeMock.mockReset();
+    sendMessageMock.mockReset();
+    mockManagedQuery.busy = false;
+    mockManagedQuery.sessionId = "existing-session";
+    mockManagedQuery.canUseToolHandler = { current: null };
     sessionState.sessionId = "existing-session";
     sessionState.workDir = "/work/test";
     sessionState.model = "claude-opus-4-6";
@@ -92,8 +124,8 @@ describe("handleMessage passes permission + prompt handlers", () => {
     sessionState.permissionMode = "default";
   });
 
-  it("passes canUseTool to runClaude when permissionMode is default", async () => {
-    runClaudeMock.mockResolvedValue({
+  it("sets canUseToolHandler on managed query when permissionMode is default", async () => {
+    sendMessageMock.mockResolvedValue({
       result: "Done",
       sessionId: "sess-1",
       tools: [],
@@ -109,18 +141,14 @@ describe("handleMessage passes permission + prompt handlers", () => {
       })
       .startTest();
 
-    expect(runClaudeMock).toHaveBeenCalledOnce();
-
-    // The 9th argument (index 8) is runOptions
-    const args = runClaudeMock.mock.calls[0];
-    const runOptions = args[8];
-    expect(runOptions).toBeDefined();
-    expect(runOptions.canUseTool).toBeDefined();
-    expect(typeof runOptions.canUseTool).toBe("function");
+    expect(sendMessageMock).toHaveBeenCalledOnce();
+    // When permissionMode is default, canUseToolHandler should be set
+    expect(mockManagedQuery.canUseToolHandler.current).toBeDefined();
+    expect(typeof mockManagedQuery.canUseToolHandler.current).toBe("function");
   });
 
-  it("passes onPromptRequest to runClaude", async () => {
-    runClaudeMock.mockResolvedValue({
+  it("passes onPromptRequest to sendMessage handlers", async () => {
+    sendMessageMock.mockResolvedValue({
       result: "Done",
       sessionId: "sess-2",
       tools: [],
@@ -136,17 +164,17 @@ describe("handleMessage passes permission + prompt handlers", () => {
       })
       .startTest();
 
-    const args = runClaudeMock.mock.calls[0];
-    const runOptions = args[8];
-    expect(runOptions).toBeDefined();
-    expect(runOptions.onPromptRequest).toBeDefined();
-    expect(typeof runOptions.onPromptRequest).toBe("function");
+    const args = sendMessageMock.mock.calls[0];
+    const handlers = args[2]; // TurnHandlers
+    expect(handlers).toBeDefined();
+    expect(handlers.onPromptRequest).toBeDefined();
+    expect(typeof handlers.onPromptRequest).toBe("function");
   });
 
-  it("does NOT pass canUseTool when permissionMode is bypassPermissions", async () => {
+  it("clears canUseToolHandler when permissionMode is bypassPermissions", async () => {
     sessionState.permissionMode = "bypassPermissions";
 
-    runClaudeMock.mockResolvedValue({
+    sendMessageMock.mockResolvedValue({
       result: "Done fast",
       sessionId: "sess-3",
       tools: [],
@@ -162,10 +190,8 @@ describe("handleMessage passes permission + prompt handlers", () => {
       })
       .startTest();
 
-    const args = runClaudeMock.mock.calls[0];
-    const runOptions = args[8];
-    // canUseTool should be undefined when bypassing permissions
-    expect(runOptions?.canUseTool).toBeUndefined();
+    // canUseToolHandler should be null when bypassing permissions
+    expect(mockManagedQuery.canUseToolHandler.current).toBeNull();
   });
 
   it("canUseTool callback sends permission card and resolves on Allow", async () => {
@@ -173,9 +199,9 @@ describe("handleMessage passes permission + prompt handlers", () => {
       | ((...args: unknown[]) => Promise<unknown>)
       | undefined;
 
-    runClaudeMock.mockImplementation(async (...args: unknown[]) => {
-      const runOptions = args[8] as Record<string, unknown> | undefined;
-      capturedCanUseTool = runOptions?.canUseTool as typeof capturedCanUseTool;
+    sendMessageMock.mockImplementation(async () => {
+      // Capture the canUseToolHandler that was set on the managed query
+      capturedCanUseTool = mockManagedQuery.canUseToolHandler.current as typeof capturedCanUseTool;
 
       if (capturedCanUseTool) {
         const { resolvePermission } =
@@ -196,7 +222,7 @@ describe("handleMessage passes permission + prompt handlers", () => {
         resolvePermission("tool-perm-1", true);
 
         const result = await resultPromise;
-        expect(result.behavior).toBe("allow");
+        expect((result as Record<string, unknown>).behavior).toBe("allow");
       }
 
       return {
@@ -219,15 +245,13 @@ describe("handleMessage passes permission + prompt handlers", () => {
     expect(capturedCanUseTool).toBeDefined();
   });
 
-  it("onPromptRequest callback sends prompt card and resolves on selection", async () => {
+  it("onPromptRequest handler sends prompt card and resolves on selection", async () => {
     let capturedOnPromptRequest:
       | ((...args: unknown[]) => Promise<unknown>)
       | undefined;
 
-    runClaudeMock.mockImplementation(async (...args: unknown[]) => {
-      const runOptions = args[8] as Record<string, unknown> | undefined;
-      capturedOnPromptRequest =
-        runOptions?.onPromptRequest as typeof capturedOnPromptRequest;
+    sendMessageMock.mockImplementation(async (_managed: unknown, _text: unknown, handlers: Record<string, unknown>) => {
+      capturedOnPromptRequest = handlers?.onPromptRequest as typeof capturedOnPromptRequest;
 
       if (capturedOnPromptRequest) {
         const { resolvePromptRequest } =

--- a/tests/bot.integration.test.ts
+++ b/tests/bot.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestAdapter, ActivityTypes, type Activity } from "botbuilder";
 
 const runClaudeMock = vi.fn();
+const sendMessageMock = vi.fn();
 
 const sessionState = {
   sessionId: undefined as string | undefined,
@@ -30,6 +31,33 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 
 vi.mock("../src/claude/agent.js", () => ({
   runClaude: (...args: unknown[]) => runClaudeMock(...args),
+  saveImagesToTmp: vi.fn(async () => []),
+}));
+
+// Mock the query pool — sendMessage is the primary path now
+const mockManagedQuery = {
+  query: { interrupt: vi.fn(), setModel: vi.fn(), close: vi.fn() },
+  inputQueue: { push: vi.fn(), end: vi.fn() },
+  conversationId: "conv-1",
+  lastActivityAt: Date.now(),
+  busy: false,
+  sessionId: undefined as string | undefined,
+  currentTurn: null,
+  streamDrainer: Promise.resolve(),
+  permissionMode: { current: "bypassPermissions" },
+  canUseToolHandler: { current: null },
+};
+
+vi.mock("../src/session/query-pool.js", () => ({
+  queryPool: {
+    acquire: vi.fn(() => mockManagedQuery),
+    sendMessage: (...args: unknown[]) => sendMessageMock(...args),
+    remove: vi.fn(async () => {}),
+    closeAll: vi.fn(async () => {}),
+    has: vi.fn(() => false),
+    get: vi.fn(() => undefined),
+    size: 0,
+  },
 }));
 
 vi.mock("../src/handoff/store.js", () => ({
@@ -105,6 +133,9 @@ describe("ClaudeCodeBot e2e (TestAdapter)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     runClaudeMock.mockReset();
+    sendMessageMock.mockReset();
+    mockManagedQuery.busy = false;
+    mockManagedQuery.sessionId = undefined;
     sessionState.sessionId = undefined;
     sessionState.workDir = "/work/test";
     sessionState.model = "claude-opus-4-6";
@@ -116,7 +147,7 @@ describe("ClaudeCodeBot e2e (TestAdapter)", () => {
   });
 
   it("handles basic message flow", async () => {
-    runClaudeMock.mockResolvedValue({
+    sendMessageMock.mockResolvedValue({
       result: "Hello from Claude",
       sessionId: "sess-123",
       tools: [],
@@ -133,20 +164,15 @@ describe("ClaudeCodeBot e2e (TestAdapter)", () => {
       })
       .startTest();
 
-    expect(runClaudeMock).toHaveBeenCalledOnce();
-    expect(runClaudeMock).toHaveBeenCalledWith(
-      "Hello",
-      undefined,
-      "/work/test",
-      "claude-opus-4-6",
-      2048,
-      "bypassPermissions",
-      undefined,
-      expect.any(Function),
-      expect.objectContaining({
-        onPromptRequest: expect.any(Function),
-      }),
-    );
+    expect(sendMessageMock).toHaveBeenCalledOnce();
+    // sendMessage(managed, text, handlers)
+    const args = sendMessageMock.mock.calls[0];
+    expect(args[0]).toBe(mockManagedQuery);
+    expect(args[1]).toBe("Hello");
+    expect(args[2]).toMatchObject({
+      onProgress: expect.any(Function),
+      onPromptRequest: expect.any(Function),
+    });
     expect(vi.mocked(sessionManager.setSession)).toHaveBeenCalledWith(
       "conv-1",
       "sess-123",
@@ -169,7 +195,7 @@ describe("ClaudeCodeBot e2e (TestAdapter)", () => {
       })
       .startTest();
 
-    expect(runClaudeMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
   it("handles /status command", async () => {


### PR DESCRIPTION
## Summary
- Replace per-message `runClaude` (single-shot) with persistent `QueryPool` using SDK's recommended streaming input mode (`AsyncGenerator` prompt)
- Fix interrupt race conditions: explicitly reject in-flight turns to prevent hung promises
- Add 10-minute turn timeout, graceful shutdown, and auto-fallback for session resumption

## Details

### Architecture
- **`AsyncQueue`** + **`QueryPool`**: each conversation gets a long-lived CLI subprocess, messages fed via async generator
- `continue: true` resumes the most recent session in the working directory; auto-retries with fresh session on failure
- Handoff routes through `fallbackRunClaude` to preserve `resume: "fork"` support

### Bug fixes
- Interrupt safely rejects `currentTurn` instead of leaving orphaned promises
- `sendMessage` guards against concurrent calls overwriting `currentTurn`
- Progress notifications now extracted from `assistant` message `tool_use` blocks (streaming mode doesn't emit separate `tool_progress` events)
- `void ctx.sendActivity()` replaced with `.catch()` to log permission card delivery errors
- Interrupted turn errors silenced from user display

## Test plan
- [x] TypeScript compiles without errors
- [x] All 74 tests pass
- [x] Verified in Teams: normal message flow works
- [x] Verified in Teams: interrupt (send new message while busy) works without error display
- [x] Verified in Teams: progress messages show during tool use
- [x] Verified in Teams: `continue: true` resumes session after bot restart
- [x] Verified: graceful shutdown closes queries within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)