### PR TITLE
feat: proactive send+update for post-stream-expiry progress

### DIFF
--- a/src/bot/bridge.ts
+++ b/src/bot/bridge.ts
@@ -18,8 +18,7 @@ import { ConversationSession, type SessionConfig } from "../claude/session.js";
 import {
   formatResponse,
   splitMessage,
-  codeBlockLanguage,
-  formatProgressMessage,
+  progressToText,
 } from "../claude/formatter.js";
 import { createToolInterceptor } from "../claude/tool-interceptor.js";
 import { buildToolCard } from "./cards.js";
@@ -54,6 +53,7 @@ export function createStreamingProgress(
     onProgress: (event: ProgressEvent) => {
       if (event.type === "done") return;
 
+      // Thinking: show in stream placeholder before first real content
       if (event.type === "thinking") {
         thinkingText += event.text;
         if (!hasEmitted) {
@@ -65,84 +65,8 @@ export function createStreamingProgress(
         return;
       }
 
-      if (event.type === "file_diff") {
-
-        const cwd = state.getWorkDir();
-        const shortPath = event.filePath?.startsWith(cwd + "/")
-          ? event.filePath.slice(cwd.length + 1)
-          : event.filePath;
-        const label = shortPath ?? "file";
-        if (event.patch) {
-          const lang = event.filePath
-            ? codeBlockLanguage(event.filePath)
-            : "plaintext";
-          emit(`\n\n📝 ${label}\n\`\`\`${lang}\n${event.patch}\n\`\`\`\n\n`);
-        } else {
-          emit(`\n\n📝 Edited ${label}\n\n`);
-        }
-        return;
-      }
-
-      if (event.type === "tool_result") {
-
-        emit(`\n\n${event.result}\n\n`);
-        return;
-      }
-
-      if (event.type === "auth_error") {
-
-        emit("\n\n🔑 Login expired — run `claude login` in terminal\n\n");
-        return;
-      }
-
-      if (event.type === "todo") {
-
-        const completed = event.todos.filter(
-          (t) => t.status === "completed",
-        ).length;
-        const lines = event.todos.map((t) => {
-          const icon =
-            t.status === "completed"
-              ? "✅"
-              : t.status === "in_progress"
-                ? "🔧"
-                : "⏳";
-          const text =
-            t.status === "in_progress" && t.activeForm
-              ? t.activeForm
-              : t.content;
-          return `${icon} ${text}`;
-        });
-        emit(
-          `\n\n📋 ${completed}/${event.todos.length}\n\n${lines.join("\n\n")}\n\n`,
-        );
-        return;
-      }
-
-      if (event.type === "rate_limit") {
-
-        const msg =
-          event.status === "rejected"
-            ? `⚠️ Rate limited.${event.resetsAt ? ` Resets at ${new Date(event.resetsAt).toLocaleTimeString()}.` : ""}`
-            : `⚠️ Approaching rate limit.${event.resetsAt ? ` Resets at ${new Date(event.resetsAt).toLocaleTimeString()}.` : ""}`;
-        emit(`\n\n${msg}\n\n`);
-        return;
-      }
-
-      if (event.type === "text") {
-        if (event.text) {
-          emit(event.text);
-        }
-        return;
-      }
-
-      // tool_use, tool_summary, task_status → emit as text in the stream
-      // Note: stream.update() only works before first text chunk (SDK limitation),
-      // so we use emit() for all progress to keep it visible throughout the turn.
-      const message = formatProgressMessage(event);
-      if (message) {
-        emit("\n\n" + message + "\n\n");
-      }
+      const text = progressToText(event, state.getWorkDir());
+      if (text) emit(text);
     },
     finalize: async (chunks: string[]) => {
       // Stream auto-closes when handler returns, merging emitted text into final message.
@@ -155,19 +79,70 @@ export function createStreamingProgress(
   };
 }
 
-// ─── Proactive progress (handoff context, no active stream) ─────────────
+// ─── Proactive progress (stream expired or handoff, no active stream) ────
+// Send+update pattern with trailing-edge throttle and serial execution.
+// All async ops go through a promise chain — no concurrent sends, no deadlocks.
+
+const INITIAL_DELAY_MS = 500;
+const UPDATE_THROTTLE_MS = 1500;
+const MAX_MSG_LEN = 25_000;
 
 export function createProactiveProgress(
   sendFn: (activity: ActivityParams) => Promise<SentActivity | undefined>,
+  updateFn: (activityId: string, activity: ActivityParams) => Promise<void>,
 ): {
   onProgress: (event: ProgressEvent) => void;
   finalize: (chunks: string[]) => Promise<void>;
 } {
+  let activityId: string | undefined;
+  let buffer = "";
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let chain = Promise.resolve();
+
+  const flush = () => {
+    if (!buffer) return;
+    const snapshot = buffer;
+    const targetId = activityId; // capture — rollover resets activityId before chain runs
+    chain = chain.then(async () => {
+      try {
+        if (!targetId) {
+          const resp = await sendFn(new MessageActivity(snapshot));
+          if (resp?.id) activityId = resp.id;
+        } else {
+          await updateFn(targetId, new MessageActivity(snapshot));
+        }
+      } catch { /* transient Teams failure */ }
+    });
+  };
+
+  const scheduleFlush = () => {
+    if (timer) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      flush();
+    }, activityId ? UPDATE_THROTTLE_MS : INITIAL_DELAY_MS);
+  };
+
   return {
-    onProgress: (_event: ProgressEvent) => {
-      // All events (including status, done) handled at session level
+    onProgress: (event: ProgressEvent) => {
+      // Skip text — it arrives in finalize as the formatted response.
+      // Only show operational progress (tools, edits, errors).
+      if (event.type === "text" || event.type === "thinking") return;
+      const chunk = progressToText(event, state.getWorkDir());
+      if (!chunk) return;
+      buffer += chunk;
+      if (buffer.length >= MAX_MSG_LEN) {
+        if (timer) { clearTimeout(timer); timer = undefined; }
+        flush();
+        activityId = undefined;
+        buffer = "";
+      } else {
+        scheduleFlush();
+      }
     },
     finalize: async (chunks: string[]) => {
+      if (timer) { clearTimeout(timer); timer = undefined; }
+      await chain;
       for (const chunk of chunks) {
         await sendFn(new MessageActivity(chunk));
       }
@@ -404,15 +379,17 @@ export function createManagedSession(
           proactiveSend,
         );
       } else {
-        currentProgress = createProactiveProgress(proactiveSend);
+        currentProgress = createProactiveProgress(proactiveSend, proactiveUpdate);
       }
     }
-    // If stream expired mid-turn, discard the dead streaming progress
-    // and switch to proactive so onResult's finalize sends all chunks.
+    // If stream expired mid-turn, switch to proactive for remaining progress.
+    // The frozen streaming message keeps its partial content. Proactive
+    // shows tool/edit progress in a new message; finalize sends the
+    // formatted response as yet another new message.
     const managed = state.getSession();
     if (managed?.streamExpired && !switchedToProactive) {
       switchedToProactive = true;
-      currentProgress = createProactiveProgress(proactiveSend);
+      currentProgress = createProactiveProgress(proactiveSend, proactiveUpdate);
     }
     return currentProgress;
   };
@@ -564,47 +541,50 @@ export function createManagedSession(
       currentProgress = null;
       switchedToProactive = false;
 
-      try {
-        state.addUsage(result.costUsd, result.usage);
+      state.addUsage(result.costUsd, result.usage);
 
-        if (result.error) {
-          console.error(`[BOT] Error from session: ${result.error}`);
-          await progress.finalize([
-            friendlyError(result.error, result.stopReason),
-          ]);
-        } else if (result.interrupted) {
-          console.log("[BOT] Turn was interrupted");
-          if (result.result) {
-            await progress.finalize(splitMessage(result.result));
-          }
-        } else if (!result.result) {
-          // Nothing to send (e.g. /compact) — turn completion is the signal
-          console.log("[BOT] Turn complete (no output)");
-        } else {
-          console.log("[BOT] Formatting and sending response");
-          await progress.finalize(splitMessage(formatResponse(result)));
-        }
+      // Compute chunks to send
+      let chunks: string[];
+      if (result.error) {
+        console.error(`[BOT] Error from session: ${result.error}`);
+        chunks = [friendlyError(result.error, result.stopReason)];
+      } else if (result.interrupted) {
+        console.log("[BOT] Turn was interrupted");
+        chunks = result.result ? splitMessage(result.result) : [];
+      } else if (!result.result) {
+        console.log("[BOT] Turn complete (no output)");
+        chunks = [];
+      } else {
+        console.log("[BOT] Formatting and sending response");
+        chunks = splitMessage(formatResponse(result));
+      }
 
-        console.log("[BOT] Response sent successfully");
-      } finally {
-        // Always signal turn completion so the message handler can return
-        if (streamTimer) {
-          clearTimeout(streamTimer);
-          streamTimer = undefined;
-        }
-        const managed = state.getSession();
-        if (managed?.stream) {
-          managed.stream = undefined;
-          managed.streamActivated = false;
-        }
-        if (managed?.streamExpired) {
-          managed.streamExpired = false;
-        }
-        if (managed?.onTurnComplete) {
-          const resolve = managed.onTurnComplete;
-          managed.onTurnComplete = undefined;
-          resolve();
-        }
+      // Fire-and-forget: message delivery must never block session processing.
+      // If finalize hangs, subsequent messages still get processed.
+      if (chunks.length > 0) {
+        progress.finalize(chunks).then(
+          () => console.log("[BOT] Response sent successfully"),
+          (err) => console.error("[BOT] finalize error:", err),
+        );
+      }
+
+      // Always clean up immediately — never gated by finalize
+      if (streamTimer) {
+        clearTimeout(streamTimer);
+        streamTimer = undefined;
+      }
+      const managed = state.getSession();
+      if (managed?.stream) {
+        managed.stream = undefined;
+        managed.streamActivated = false;
+      }
+      if (managed?.streamExpired) {
+        managed.streamExpired = false;
+      }
+      if (managed?.onTurnComplete) {
+        const resolve = managed.onTurnComplete;
+        managed.onTurnComplete = undefined;
+        resolve();
       }
     },
   };

--- a/src/claude/formatter.ts
+++ b/src/claude/formatter.ts
@@ -85,6 +85,41 @@ export function formatProgressMessage(
   return `🔧 Running: ${tool.name}`;
 }
 
+/** Convert a progress event to displayable text. Shared by streaming and proactive paths. */
+export function progressToText(event: ProgressEvent, cwd?: string): string | undefined {
+  if (event.type === "text" && event.text) return event.text;
+  if (event.type === "file_diff") {
+    const shortPath = cwd && event.filePath?.startsWith(cwd + "/")
+      ? event.filePath.slice(cwd.length + 1)
+      : event.filePath;
+    const label = shortPath ?? "file";
+    if (event.patch) {
+      const lang = event.filePath ? codeBlockLanguage(event.filePath) : "plaintext";
+      return `\n\n📝 ${label}\n\`\`\`${lang}\n${event.patch}\n\`\`\`\n\n`;
+    }
+    return `\n\n📝 Edited ${label}\n\n`;
+  }
+  if (event.type === "tool_result" && event.result) return `\n\n${event.result}\n\n`;
+  if (event.type === "auth_error") return "\n\n🔑 Login expired — run `claude login` in terminal\n\n";
+  if (event.type === "todo") {
+    const completed = event.todos.filter((t) => t.status === "completed").length;
+    const lines = event.todos.map((t) => {
+      const icon = t.status === "completed" ? "✅" : t.status === "in_progress" ? "🔧" : "⏳";
+      const text = t.status === "in_progress" && t.activeForm ? t.activeForm : t.content;
+      return `${icon} ${text}`;
+    });
+    return `\n\n📋 ${completed}/${event.todos.length}\n\n${lines.join("\n\n")}\n\n`;
+  }
+  if (event.type === "rate_limit") {
+    const reset = event.resetsAt ? ` Resets at ${new Date(event.resetsAt).toLocaleTimeString()}.` : "";
+    return event.status === "rejected"
+      ? `\n\n⚠️ Rate limited.${reset}\n\n`
+      : `\n\n⚠️ Approaching rate limit.${reset}\n\n`;
+  }
+  const msg = formatProgressMessage(event);
+  return msg ? "\n\n" + msg + "\n\n" : undefined;
+}
+
 export function formatResponse(result: ClaudeResult): string {
   return result.result || "Done (no output)";
 }

--- a/tests/bot.integration.test.ts
+++ b/tests/bot.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---- Mock SDK ----
 const mockQuery = vi.fn();
@@ -770,54 +770,145 @@ describe("streaming progress via stream.emit", () => {
   });
 });
 
-describe("proactive progress (handoff context)", () => {
-  it("ignores all progress events except done", () => {
+describe("proactive progress (send+update)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("tool_use events are accumulated as progress text", async () => {
     const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
 
-    const progress = createProactiveProgress(sendFn);
+    const progress = createProactiveProgress(sendFn, updateFn);
 
-    progress.onProgress({ type: "text", text: "Hello" });
     progress.onProgress({
       type: "tool_use",
       tool: { name: "Bash", command: "ls" },
     });
-    progress.onProgress({
-      type: "file_diff",
-      filePath: "src/index.ts",
-      patch: "diff",
-    });
 
-    expect(sendFn).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sendFn).toHaveBeenCalledTimes(1);
   });
 
-  it("done event is ignored by proactive progress", () => {
+  it("done events are ignored", () => {
     const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
 
-    const progress = createProactiveProgress(sendFn);
+    const progress = createProactiveProgress(sendFn, updateFn);
 
     progress.onProgress({ type: "done" });
 
+    vi.advanceTimersByTime(2000);
+    expect(sendFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it("text events are skipped (delivered via finalize)", () => {
+    const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
+
+    const progress = createProactiveProgress(sendFn, updateFn);
+
+    progress.onProgress({ type: "text", text: "Hello" });
+    vi.advanceTimersByTime(2000);
     expect(sendFn).not.toHaveBeenCalled();
   });
 
-  it("finalize sends each chunk as a new message", async () => {
+  it("first progress sends after initial delay (500ms)", async () => {
     const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
 
-    const progress = createProactiveProgress(sendFn);
+    const progress = createProactiveProgress(sendFn, updateFn);
 
-    await progress.finalize(["Chunk 1", "Chunk 2", "Chunk 3"]);
+    progress.onProgress({ type: "tool_use", tool: { name: "Read", file: "foo.ts" } } as never);
+    expect(sendFn).not.toHaveBeenCalled();
 
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it("subsequent progress updates after 1.5s throttle", async () => {
+    const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
+
+    const progress = createProactiveProgress(sendFn, updateFn);
+
+    progress.onProgress({ type: "tool_use", tool: { name: "Read", file: "a.ts" } } as never);
+    await vi.advanceTimersByTimeAsync(500); // initial delay
+
+    progress.onProgress({ type: "tool_use", tool: { name: "Edit", file: "b.ts" } } as never);
+    await vi.advanceTimersByTimeAsync(1500); // update throttle
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(updateFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("finalize sends as new messages (does not replace progress)", async () => {
+    const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
+
+    const progress = createProactiveProgress(sendFn, updateFn);
+
+    progress.onProgress({ type: "tool_use", tool: { name: "Bash", command: "ls" } } as never);
+    await vi.advanceTimersByTimeAsync(500);
+
+    await progress.finalize(["**Formatted**", "Overflow chunk"]);
+
+    // progress send + 2 finalize chunks = 3 sends
     expect(sendFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("finalize without prior send falls back to sendFn", async () => {
+    const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
+
+    const progress = createProactiveProgress(sendFn, updateFn);
+
+    await progress.finalize(["Chunk 1", "Chunk 2"]);
+
+    expect(sendFn).toHaveBeenCalledTimes(2);
+    expect(updateFn).not.toHaveBeenCalled();
   });
 
   it("finalize with empty chunks does nothing", async () => {
     const sendFn = vi.fn(async () => ({ id: "msg-1" }));
+    const updateFn = vi.fn(async () => {});
 
-    const progress = createProactiveProgress(sendFn);
+    const progress = createProactiveProgress(sendFn, updateFn);
 
     await progress.finalize([]);
 
     expect(sendFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it("rollover updates old message then starts new one", async () => {
+    let msgCount = 0;
+    const sendFn = vi.fn(async () => ({ id: `msg-${++msgCount}` }));
+    const updateFn = vi.fn(async () => {});
+
+    const progress = createProactiveProgress(sendFn, updateFn);
+
+    // First progress → triggers initial send
+    progress.onProgress({ type: "tool_use", tool: { name: "Bash", command: "ls" } } as never);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sendFn).toHaveBeenCalledTimes(1); // msg-1 created
+
+    // Push buffer over 25KB with a huge tool_result to trigger rollover
+    progress.onProgress({ type: "tool_result", result: "X".repeat(25_000) } as never);
+
+    // Rollover: flush updates msg-1 (not creates new), then resets
+    await vi.advanceTimersByTimeAsync(0); // drain chain
+    expect(updateFn).toHaveBeenCalledTimes(1); // msg-1 updated with full buffer
+
+    // New progress after rollover creates a new message
+    progress.onProgress({ type: "tool_use", tool: { name: "Edit", file: "c.ts" } } as never);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sendFn).toHaveBeenCalledTimes(2); // msg-2 created
   });
 });
 

--- a/tests/bridge-utils.test.ts
+++ b/tests/bridge-utils.test.ts
@@ -4,6 +4,7 @@ import {
   formatProgressMessage,
   truncateProgress,
   codeBlockLanguage,
+  progressToText,
 } from "../src/claude/formatter.js";
 
 describe("friendlyError", () => {
@@ -182,5 +183,71 @@ describe("codeBlockLanguage", () => {
 
   it("returns plaintext for no extension", () => {
     expect(codeBlockLanguage("Makefile")).toBe("plaintext");
+  });
+});
+
+describe("progressToText", () => {
+  it("returns text content for text events", () => {
+    expect(progressToText({ type: "text", text: "hello" })).toBe("hello");
+  });
+
+  it("returns undefined for empty text", () => {
+    expect(progressToText({ type: "text", text: "" })).toBeUndefined();
+  });
+
+  it("returns undefined for done events", () => {
+    expect(progressToText({ type: "done" } as never)).toBeUndefined();
+  });
+
+  it("formats file_diff with language tag", () => {
+    const result = progressToText({
+      type: "file_diff",
+      filePath: "/proj/src/index.ts",
+      patch: "+code",
+    } as never);
+    expect(result).toContain("```typescript");
+    expect(result).toContain("+code");
+  });
+
+  it("shortens file_diff paths relative to cwd", () => {
+    const result = progressToText(
+      { type: "file_diff", filePath: "/proj/src/index.ts", patch: "diff" } as never,
+      "/proj",
+    );
+    expect(result).toContain("📝 src/index.ts");
+  });
+
+  it("formats auth_error", () => {
+    const result = progressToText({ type: "auth_error", error: "expired" } as never);
+    expect(result).toContain("🔑");
+  });
+
+  it("formats todo list", () => {
+    const result = progressToText({
+      type: "todo",
+      todos: [
+        { content: "Task 1", status: "completed" },
+        { content: "Task 2", status: "in_progress" },
+      ],
+    } as never);
+    expect(result).toContain("✅ Task 1");
+    expect(result).toContain("🔧 Task 2");
+    expect(result).toContain("1/2");
+  });
+
+  it("formats rate_limit rejected", () => {
+    const result = progressToText({
+      type: "rate_limit",
+      status: "rejected",
+    } as never);
+    expect(result).toContain("Rate limited");
+  });
+
+  it("delegates tool_use to formatProgressMessage", () => {
+    const result = progressToText({
+      type: "tool_use",
+      tool: { name: "Bash", command: "ls" },
+    } as never);
+    expect(result).toContain("🔧 Running: ls");
   });
 });


### PR DESCRIPTION
## Summary
- **progressToText**: shared event formatter extracted to `formatter.ts`, eliminates duplication between streaming and proactive paths
- **Proactive send+update**: after 90s stream expiry, shows tool/edit progress via throttled send+update pattern with promise chain serialisation (fixes inflight deadlock)
- **Non-blocking finalize**: `onResult` fires finalize as fire-and-forget — message delivery never blocks session processing, subsequent messages always go through

## Design
- Proactive progress only shows operational events (tool_use, file_diff, todo, etc.), text is reserved for finalize → no duplicate content
- Promise chain replaces fragile `inflight` pattern — all async ops serialised, no deadlock on rollover
- `flush()` captures `activityId` at call time (not execution time) to avoid stale reference after rollover

## Test plan
- [x] 239 tests passing
- [ ] Verify streaming works normally (text flows, finalize replaces)
- [ ] Trigger stream expiry (90s) — confirm tool/edit progress appears as proactive messages
- [ ] Confirm final response arrives as separate message after progress
- [ ] Send follow-up message during long turn — confirm it's not blocked