### PR TITLE
fix(cli): improve Windows stop/start/restart/status experience

### DIFF
--- a/src/bot/bridge.ts
+++ b/src/bot/bridge.ts
@@ -80,18 +80,35 @@ function imageTooLargeMessage(event: ImageEvent): string {
 
 // ─── Native streaming progress (uses ctx.stream) ────────────────────────
 
+/** Max buffered text length before flushing to stream (allows reaction detection). */
+const REACTION_BUFFER_MAX = 20;
+
+export interface Progress {
+  onProgress: (event: ProgressEvent) => void;
+  finalize: (chunks: string[]) => Promise<void>;
+  /** Buffered text not yet emitted (streaming only). */
+  getBufferedText?: () => string;
+}
+
 export function createStreamingProgress(
   stream: IStreamer,
   sendFn: (activity: ActivityParams) => Promise<SentActivity | undefined>,
-): {
-  onProgress: (event: ProgressEvent) => void;
-  finalize: (chunks: string[]) => Promise<void>;
-} {
+): Progress {
   let hasEmitted = false;
+  let textBuffer = "";
+  let bufferFlushed = false;
 
   const emit = (content: string) => {
     hasEmitted = true;
     stream.emit(content);
+  };
+
+  const flushBuffer = () => {
+    if (textBuffer && !bufferFlushed) {
+      emit(textBuffer);
+      textBuffer = "";
+    }
+    bufferFlushed = true;
   };
 
   let thinkingText = "";
@@ -112,7 +129,7 @@ export function createStreamingProgress(
       }
 
       if (event.type === "file_diff") {
-
+        flushBuffer();
         const cwd = state.getWorkDir();
         const shortPath = event.filePath?.startsWith(cwd + "/")
           ? event.filePath.slice(cwd.length + 1)
@@ -130,7 +147,7 @@ export function createStreamingProgress(
       }
 
       if (event.type === "tool_result") {
-
+        flushBuffer();
         emit(`\n\n${event.result}\n\n`);
         return;
       }
@@ -188,7 +205,15 @@ export function createStreamingProgress(
 
       if (event.type === "text") {
         if (event.text) {
-          emit(event.text);
+          if (bufferFlushed) {
+            // Buffer already flushed — stream directly
+            emit(event.text);
+          } else {
+            textBuffer += event.text;
+            if (textBuffer.length > REACTION_BUFFER_MAX) {
+              flushBuffer();
+            }
+          }
         }
         return;
       }
@@ -198,10 +223,12 @@ export function createStreamingProgress(
       // so we use emit() for all progress to keep it visible throughout the turn.
       const message = formatProgressMessage(event);
       if (message) {
+        flushBuffer();
         emit("\n\n" + message + "\n\n");
       }
     },
     finalize: async (chunks: string[]) => {
+      flushBuffer();
       // Stream auto-closes when handler returns, merging emitted text into final message.
       // If nothing was emitted (e.g. error path), send all chunks proactively.
       const start = hasEmitted ? 1 : 0;
@@ -209,6 +236,7 @@ export function createStreamingProgress(
         await sendFn(new MessageActivity(chunks[i]));
       }
     },
+    getBufferedText: () => textBuffer,
   };
 }
 
@@ -216,10 +244,7 @@ export function createStreamingProgress(
 
 export function createProactiveProgress(
   sendFn: (activity: ActivityParams) => Promise<SentActivity | undefined>,
-): {
-  onProgress: (event: ProgressEvent) => void;
-  finalize: (chunks: string[]) => Promise<void>;
-} {
+): Progress {
   return {
     onProgress: (event: ProgressEvent) => {
       if (event.type === "image") {
@@ -457,7 +482,7 @@ export function createManagedSession(
   // Auto-managed progress — created on first event, destroyed on result.
   // Stream is activated on "started" (message_start). Before that, everything
   // is proactive (including compacting status). Timer starts on activation.
-  let currentProgress: ReturnType<typeof createStreamingProgress> | null = null;
+  let currentProgress: Progress | null = null;
   let switchedToProactive = false;
   let compactingActivityId: string | undefined;
   let compactingSend: Promise<void> | undefined;
@@ -483,7 +508,7 @@ export function createManagedSession(
       switchedToProactive = true;
       currentProgress = createProactiveProgress(proactiveSend);
     }
-    return currentProgress;
+    return currentProgress!;
   };
 
   const sessionConfig: SessionConfig = {
@@ -650,18 +675,19 @@ export function createManagedSession(
           // Nothing to send (e.g. /compact) — turn completion is the signal
           console.log("[BOT] Turn complete (no output)");
         } else {
-          // Check if response is a single emoji that can be sent as a reaction
+          // Check if response is a single emoji that can be sent as a reaction.
+          // Use buffered text (not yet emitted to stream) for clean reaction UX.
           const managed = state.getSession();
-          const reactionType = getReactionType(result.result);
+          const buffered = progress.getBufferedText?.() ?? "";
+          const reactionType = buffered ? getReactionType(buffered) : getReactionType(result.result);
           if (reactionType && managed?.userActivityId && conversationId) {
             try {
               console.log(`[BOT] Sending reaction: ${reactionType}`);
               await app.api.reactions.add(conversationId, managed.userActivityId, reactionType);
-              // Close stream silently — no text to emit
-              await progress.finalize([]);
+              // Don't flush buffer — close stream silently with no text
             } catch (err) {
               console.warn("[BOT] Reaction failed, falling back to text:", err);
-              await progress.finalize(splitMessage(formatResponse(result)));
+              progress.finalize(splitMessage(formatResponse(result)));
             }
           } else {
             console.log("[BOT] Formatting and sending response");

--- a/src/bot/bridge.ts
+++ b/src/bot/bridge.ts
@@ -80,14 +80,9 @@ function imageTooLargeMessage(event: ImageEvent): string {
 
 // ─── Native streaming progress (uses ctx.stream) ────────────────────────
 
-/** Max buffered text length before flushing to stream (allows reaction detection). */
-const REACTION_BUFFER_MAX = 20;
-
 export interface Progress {
   onProgress: (event: ProgressEvent) => void;
   finalize: (chunks: string[]) => Promise<void>;
-  /** Buffered text not yet emitted (streaming only). */
-  getBufferedText?: () => string;
 }
 
 export function createStreamingProgress(
@@ -95,20 +90,10 @@ export function createStreamingProgress(
   sendFn: (activity: ActivityParams) => Promise<SentActivity | undefined>,
 ): Progress {
   let hasEmitted = false;
-  let textBuffer = "";
-  let bufferFlushed = false;
 
   const emit = (content: string) => {
     hasEmitted = true;
     stream.emit(content);
-  };
-
-  const flushBuffer = () => {
-    if (textBuffer && !bufferFlushed) {
-      emit(textBuffer);
-      textBuffer = "";
-    }
-    bufferFlushed = true;
   };
 
   let thinkingText = "";
@@ -129,7 +114,7 @@ export function createStreamingProgress(
       }
 
       if (event.type === "file_diff") {
-        flushBuffer();
+
         const cwd = state.getWorkDir();
         const shortPath = event.filePath?.startsWith(cwd + "/")
           ? event.filePath.slice(cwd.length + 1)
@@ -147,7 +132,7 @@ export function createStreamingProgress(
       }
 
       if (event.type === "tool_result") {
-        flushBuffer();
+
         emit(`\n\n${event.result}\n\n`);
         return;
       }
@@ -205,15 +190,7 @@ export function createStreamingProgress(
 
       if (event.type === "text") {
         if (event.text) {
-          if (bufferFlushed) {
-            // Buffer already flushed — stream directly
-            emit(event.text);
-          } else {
-            textBuffer += event.text;
-            if (textBuffer.length > REACTION_BUFFER_MAX) {
-              flushBuffer();
-            }
-          }
+          emit(event.text);
         }
         return;
       }
@@ -223,12 +200,10 @@ export function createStreamingProgress(
       // so we use emit() for all progress to keep it visible throughout the turn.
       const message = formatProgressMessage(event);
       if (message) {
-        flushBuffer();
         emit("\n\n" + message + "\n\n");
       }
     },
     finalize: async (chunks: string[]) => {
-      flushBuffer();
       // Stream auto-closes when handler returns, merging emitted text into final message.
       // If nothing was emitted (e.g. error path), send all chunks proactively.
       const start = hasEmitted ? 1 : 0;
@@ -236,7 +211,6 @@ export function createStreamingProgress(
         await sendFn(new MessageActivity(chunks[i]));
       }
     },
-    getBufferedText: () => textBuffer,
   };
 }
 
@@ -675,29 +649,14 @@ export function createManagedSession(
           // Nothing to send (e.g. /compact) — turn completion is the signal
           console.log("[BOT] Turn complete (no output)");
         } else {
-          // Check if response is a single emoji that can be sent as a reaction.
-          // Only when the entire response is still in the buffer (no tool output
-          // or other content was streamed before it).
+          // Detect single-emoji response — queue reaction for after stream closes
           const managed = state.getSession();
-          const buffered = progress.getBufferedText?.() ?? "";
-          const isFullyBuffered = buffered.trim() === result.result.trim();
-          const reactionType = isFullyBuffered
-            ? getReactionType(buffered)
-            : undefined;
-          if (reactionType && managed?.userActivityId && conversationId) {
-            try {
-              console.log(`[BOT] Sending reaction: ${reactionType}`);
-              await app.api.reactions.add(conversationId, managed.userActivityId, reactionType);
-              // Close stream with empty finalize — no text to show
-              await progress.finalize([]);
-            } catch (err) {
-              console.warn("[BOT] Reaction failed, falling back to text:", err);
-              await progress.finalize(splitMessage(formatResponse(result)));
-            }
-          } else {
-            console.log("[BOT] Formatting and sending response");
-            await progress.finalize(splitMessage(formatResponse(result)));
+          const reactionType = getReactionType(result.result);
+          if (reactionType && managed?.userActivityId) {
+            managed.pendingReaction = reactionType;
           }
+          console.log("[BOT] Formatting and sending response");
+          await progress.finalize(splitMessage(formatResponse(result)));
         }
 
         console.log("[BOT] Response sent successfully");

--- a/src/bot/bridge.ts
+++ b/src/bot/bridge.ts
@@ -676,18 +676,23 @@ export function createManagedSession(
           console.log("[BOT] Turn complete (no output)");
         } else {
           // Check if response is a single emoji that can be sent as a reaction.
-          // Use buffered text (not yet emitted to stream) for clean reaction UX.
+          // Only when the entire response is still in the buffer (no tool output
+          // or other content was streamed before it).
           const managed = state.getSession();
           const buffered = progress.getBufferedText?.() ?? "";
-          const reactionType = buffered ? getReactionType(buffered) : getReactionType(result.result);
+          const isFullyBuffered = buffered.trim() === result.result.trim();
+          const reactionType = isFullyBuffered
+            ? getReactionType(buffered)
+            : undefined;
           if (reactionType && managed?.userActivityId && conversationId) {
             try {
               console.log(`[BOT] Sending reaction: ${reactionType}`);
               await app.api.reactions.add(conversationId, managed.userActivityId, reactionType);
-              // Don't flush buffer — close stream silently with no text
+              // Close stream with empty finalize — no text to show
+              await progress.finalize([]);
             } catch (err) {
               console.warn("[BOT] Reaction failed, falling back to text:", err);
-              progress.finalize(splitMessage(formatResponse(result)));
+              await progress.finalize(splitMessage(formatResponse(result)));
             }
           } else {
             console.log("[BOT] Formatting and sending response");

--- a/src/bot/bridge.ts
+++ b/src/bot/bridge.ts
@@ -32,6 +32,34 @@ import type { IStreamer } from "@microsoft/teams.apps";
 import type { interactiveCards } from "./cards.js";
 type InteractiveCards = typeof interactiveCards;
 
+// ─── Emoji → reaction mapping ───────────────────────────────────────────
+
+/** Map of single-emoji responses to Teams reaction types. */
+const EMOJI_TO_REACTION: Record<string, string> = {
+  "👍": "like",
+  "👍🏻": "like",
+  "👍🏼": "like",
+  "👍🏽": "like",
+  "👍🏾": "like",
+  "👍🏿": "like",
+  "❤️": "heart",
+  "♥️": "heart",
+  "❤": "heart",
+  "👀": "1f440_eyes",
+  "✅": "2705_whiteheavycheckmark",
+  "🚀": "launch",
+  "📌": "1f4cc_pushpin",
+};
+
+/**
+ * If text is a single emoji that maps to a Teams reaction, return the reaction type.
+ * Otherwise return undefined.
+ */
+function getReactionType(text: string): string | undefined {
+  const trimmed = text.trim();
+  return EMOJI_TO_REACTION[trimmed];
+}
+
 // ─── Image helpers ──────────────────────────────────────────────────────
 
 const MAX_INLINE_BYTES = 4 * 1024 * 1024; // 4MB — Teams inline attachment limit
@@ -622,8 +650,23 @@ export function createManagedSession(
           // Nothing to send (e.g. /compact) — turn completion is the signal
           console.log("[BOT] Turn complete (no output)");
         } else {
-          console.log("[BOT] Formatting and sending response");
-          await progress.finalize(splitMessage(formatResponse(result)));
+          // Check if response is a single emoji that can be sent as a reaction
+          const managed = state.getSession();
+          const reactionType = getReactionType(result.result);
+          if (reactionType && managed?.userActivityId && conversationId) {
+            try {
+              console.log(`[BOT] Sending reaction: ${reactionType}`);
+              await app.api.reactions.add(conversationId, managed.userActivityId, reactionType);
+              // Close stream silently — no text to emit
+              await progress.finalize([]);
+            } catch (err) {
+              console.warn("[BOT] Reaction failed, falling back to text:", err);
+              await progress.finalize(splitMessage(formatResponse(result)));
+            }
+          } else {
+            console.log("[BOT] Formatting and sending response");
+            await progress.finalize(splitMessage(formatResponse(result)));
+          }
         }
 
         console.log("[BOT] Response sent successfully");

--- a/src/bot/bridge.ts
+++ b/src/bot/bridge.ts
@@ -32,32 +32,24 @@ import type { IStreamer } from "@microsoft/teams.apps";
 import type { interactiveCards } from "./cards.js";
 type InteractiveCards = typeof interactiveCards;
 
-// ─── Emoji → reaction mapping ───────────────────────────────────────────
-
-/** Map of single-emoji responses to Teams reaction types. */
-const EMOJI_TO_REACTION: Record<string, string> = {
-  "👍": "like",
-  "👍🏻": "like",
-  "👍🏼": "like",
-  "👍🏽": "like",
-  "👍🏾": "like",
-  "👍🏿": "like",
-  "❤️": "heart",
-  "♥️": "heart",
-  "❤": "heart",
-  "👀": "1f440_eyes",
-  "✅": "2705_whiteheavycheckmark",
-  "🚀": "launch",
-  "📌": "1f4cc_pushpin",
-};
+// ─── Single-emoji detection ─────────────────────────────────────────────
 
 /**
- * If text is a single emoji that maps to a Teams reaction, return the reaction type.
- * Otherwise return undefined.
+ * If text is a single emoji, return it as a reaction type string.
+ * Teams accepts arbitrary emoji strings via `(string & {})`.
+ * Uses Intl.Segmenter to correctly handle all emoji (ZWJ, flags, skin tones).
  */
 function getReactionType(text: string): string | undefined {
   const trimmed = text.trim();
-  return EMOJI_TO_REACTION[trimmed];
+  if (!trimmed) return undefined;
+  const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+  const segments = [...segmenter.segment(trimmed)];
+  if (segments.length !== 1) return undefined;
+  // Verify it's actually an emoji, not a single letter/digit
+  if (/\p{Emoji_Presentation}/u.test(trimmed) || /\p{Emoji}\uFE0F/u.test(trimmed)) {
+    return trimmed;
+  }
+  return undefined;
 }
 
 // ─── Image helpers ──────────────────────────────────────────────────────

--- a/src/bot/message.ts
+++ b/src/bot/message.ts
@@ -128,6 +128,9 @@ export function registerMessageHandler(app: App): void {
       state.setSession(managed);
     }
 
+    // Store user's activity ID for potential reaction responses
+    managed.userActivityId = activity.id;
+
     // Delete prompt suggestion card from previous turn
     if (managed.suggestionCardId && convIdForSession) {
       const cardId = managed.suggestionCardId;

--- a/src/bot/message.ts
+++ b/src/bot/message.ts
@@ -221,6 +221,23 @@ export function registerMessageHandler(app: App): void {
 
     // Await until onResult resolves (or stream expires via 403)
     await resultPromise;
+
+    // If response was a single emoji, replace the stream message with a reaction
+    if (managed.pendingReaction && managed.userActivityId && convIdForSession) {
+      const reactionType = managed.pendingReaction;
+      managed.pendingReaction = undefined;
+      // Listen for stream close to get the final message's activity ID, then delete it
+      stream.events.on("close", async (sent) => {
+        try {
+          await app.api.reactions.add(convIdForSession, managed.userActivityId!, reactionType);
+          if (sent?.id) {
+            await app.api.conversations.activities(convIdForSession).delete(sent.id);
+          }
+        } catch (err) {
+          console.warn("[BOT] Emoji reaction failed:", err);
+        }
+      });
+    }
   });
 
   // Save conversation ref on bot install

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -17,8 +17,8 @@ async function preflightCheck(): Promise<void> {
   const tunnelId = cfg.DEVTUNNEL_ID;
   if (!tunnelId) return;
 
-  // On Windows, devtunnel.exe may not resolve without shell.
-  // Pass args via shell as a single command string to avoid DEP0190 warning.
+  // On Windows, devtunnel.exe may not resolve via spawn() without a shell.
+  // Use cmd /c to let Windows handle PATH resolution.
   const isWin = process.platform === "win32";
   const devtunnel = resolveDevtunnel();
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { detectPlatform, resolveDevtunnel } from "./constants.js";
+import { type Platform, detectPlatform, resolveDevtunnel } from "./constants.js";
 import { runCommand, runBuild, pathExistsAndNonEmpty } from "./utils.js";
 import {
   installService,
@@ -17,20 +17,31 @@ async function preflightCheck(): Promise<void> {
   const tunnelId = cfg.DEVTUNNEL_ID;
   if (!tunnelId) return;
 
-  const result = await runCommand(
-    resolveDevtunnel(),
-    ["token", tunnelId, "--scope", "host"],
-    {
-      stdio: "pipe",
-      allowFailure: true,
-    },
-  );
+  // On Windows, devtunnel.exe may not resolve without shell.
+  // Pass args via shell as a single command string to avoid DEP0190 warning.
+  const isWin = process.platform === "win32";
+  const devtunnel = resolveDevtunnel();
+
+  const devtunnelRun = (args: string[], opts?: { stdio?: "pipe" | "inherit"; timeoutMs?: number }) =>
+    isWin
+      ? runCommand("cmd", ["/c", devtunnel, ...args], {
+          stdio: opts?.stdio ?? "pipe",
+          allowFailure: true,
+          timeoutMs: opts?.timeoutMs ?? 10_000,
+        })
+      : runCommand(devtunnel, args, {
+          stdio: opts?.stdio ?? "pipe",
+          allowFailure: true,
+          timeoutMs: opts?.timeoutMs ?? 10_000,
+        });
+
+  const result = await devtunnelRun(["token", tunnelId, "--scope", "host"]);
 
   if (result.code !== 0) {
     console.log("Tunnel auth expired. Logging in...");
-    const login = await runCommand(resolveDevtunnel(), ["user", "login"], {
+    const login = await devtunnelRun(["user", "login"], {
       stdio: "inherit",
-      allowFailure: true,
+      timeoutMs: 60_000,
     });
     if (login.code !== 0) {
       throw new Error(
@@ -38,14 +49,7 @@ async function preflightCheck(): Promise<void> {
       );
     }
     // Verify token works after login
-    const retry = await runCommand(
-      resolveDevtunnel(),
-      ["token", tunnelId, "--scope", "host"],
-      {
-        stdio: "pipe",
-        allowFailure: true,
-      },
-    );
+    const retry = await devtunnelRun(["token", tunnelId, "--scope", "host"]);
     if (retry.code !== 0) {
       throw new Error(
         "Tunnel auth still invalid after login. Check tunnel ownership.",
@@ -70,11 +74,19 @@ async function probe(url: string, timeoutMs: number): Promise<boolean> {
 }
 
 async function getTunnelUrl(tunnelId: string): Promise<string | undefined> {
-  const result = await runCommand(resolveDevtunnel(), ["show", tunnelId], {
-    stdio: "pipe",
-    allowFailure: true,
-    timeoutMs: 10000,
-  });
+  const devtunnel = resolveDevtunnel();
+  const isWin = process.platform === "win32";
+  const result = isWin
+    ? await runCommand("cmd", ["/c", devtunnel, "show", tunnelId], {
+        stdio: "pipe",
+        allowFailure: true,
+        timeoutMs: 10_000,
+      })
+    : await runCommand(devtunnel, ["show", tunnelId], {
+        stdio: "pipe",
+        allowFailure: true,
+        timeoutMs: 10_000,
+      });
   if (result.code !== 0) return undefined;
   const match = result.stdout.match(/(https:\/\/\S+devtunnels\.ms)\S*/);
   return match?.[1];
@@ -112,7 +124,57 @@ export async function restartCommand(): Promise<void> {
   await preflightCheck();
   await runBuild();
   await startService(platform);
-  console.log("Restarted.");
+  await pollAndShowLogs(platform);
+}
+
+/** Poll healthz and show startup log output. Shared by start and restart. */
+async function pollAndShowLogs(platform: Platform): Promise<void> {
+  console.log("Starting...");
+  const { getLogPaths } = await import("./service.js");
+  const logPaths = getLogPaths(platform);
+  let ok = false;
+  for (let i = 0; i < 15; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    ok = await probe("http://127.0.0.1:3978/healthz", 2000);
+    if (ok) break;
+  }
+
+  // Show log output (success or failure)
+  const logLines: string[] = [];
+  for (const logPath of logPaths) {
+    try {
+      const content = fs.readFileSync(logPath, "utf8").trim();
+      if (content) {
+        logLines.push(...content.split(/\r?\n/));
+      }
+    } catch {
+      /* no log file */
+    }
+  }
+
+  if (ok) {
+    // Show key lines from startup log (tunnel URL, etc.)
+    const interesting = logLines.filter(
+      (l) =>
+        l.includes("listening on port") ||
+        l.includes("Ready to accept") ||
+        l.includes("Connect via browser") ||
+        l.includes("Bot PID") ||
+        l.includes("ERROR"),
+    );
+    if (interesting.length > 0) {
+      for (const line of interesting) console.log(`  ${line}`);
+    }
+    console.log("Bot is running.");
+  } else {
+    console.error("Bot failed to start.\n");
+    const tail = logLines.slice(-15);
+    if (tail.length > 0) {
+      for (const line of tail) console.error(`  ${line}`);
+    } else {
+      console.error("  (no log output — check bash/node installation)");
+    }
+  }
 }
 
 export async function startCommand(): Promise<void> {
@@ -126,37 +188,16 @@ export async function startCommand(): Promise<void> {
 
   await preflightCheck();
   await startService(platform);
-
-  // Poll until bot is reachable or timeout
-  console.log("Starting...");
-  let ok = false;
-  for (let i = 0; i < 10; i++) {
-    await new Promise((r) => setTimeout(r, 1000));
-    ok = await probe("http://127.0.0.1:3978/healthz", 2000);
-    if (ok) break;
-  }
-  if (ok) {
-    console.log("Bot is running.");
-  } else {
-    console.error("Bot failed to start.\n");
-    // Show last few lines of log
-    const { getLogPaths } = await import("./service.js");
-    for (const logPath of getLogPaths(platform)) {
-      try {
-        const content = fs.readFileSync(logPath, "utf8").trim();
-        const lines = content.split(/\r?\n/).slice(-15);
-        console.error(lines.join("\n"));
-      } catch {
-        /* no log file */
-      }
-    }
-  }
+  await pollAndShowLogs(platform);
 }
 
 export async function stopCommand(): Promise<void> {
   const platform = detectPlatform();
   await stopService(platform);
-  console.log("Stopped.");
+  // Windows stopService prints its own status messages; mac/linux need explicit confirmation
+  if (platform !== "win32") {
+    console.log("Stopped.");
+  }
 }
 
 export async function statusCommand(): Promise<void> {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -204,13 +204,17 @@ async function windowsStopService(): Promise<void> {
         `Stop-Process -Id ${botPid} -Force -ErrorAction SilentlyContinue`,
       { allowFailure: true },
     );
-    // Kill orphaned devtunnel host processes
-    await runPowerShell(
-      `Get-CimInstance Win32_Process -Filter "Name='devtunnel.exe'" -ErrorAction SilentlyContinue | ` +
-        `Where-Object { $_.CommandLine -match 'host' } | ` +
-        `ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`,
-      { allowFailure: true },
-    );
+    // Kill devtunnel host for this bot's tunnel (scoped by tunnel ID from config)
+    const { loadExistingSetupConfig } = await import("./setup.js");
+    const tunnelId = loadExistingSetupConfig().DEVTUNNEL_ID;
+    if (tunnelId) {
+      await runPowerShell(
+        `Get-CimInstance Win32_Process -Filter "Name='devtunnel.exe'" -ErrorAction SilentlyContinue | ` +
+          `Where-Object { $_.CommandLine -match 'host' -and $_.CommandLine -match '${tunnelId}' } | ` +
+          `ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`,
+        { allowFailure: true },
+      );
+    }
     portResult = { stdout: `killed_pid_${botPid}` };
   }
 
@@ -223,7 +227,7 @@ async function windowsStopService(): Promise<void> {
   if (portOut.startsWith("killed_pid_")) {
     const pid = portOut.replace("killed_pid_", "");
     console.log(`Killed bot process (pid ${pid}).`);
-  } else if (taskOut === "no_task" && portOut === "no_process") {
+  } else if (portOut === "no_process") {
     console.log("Bot is not running.");
   }
 }
@@ -247,14 +251,17 @@ async function windowsStartBackground(): Promise<void> {
   const { spawn: spawnProc } = await import("child_process");
   const outFd = fs.openSync(winLogPath, "w");
   const errFd = fs.openSync(winErrLogPath, "w");
-  const child = spawnProc(bashPath, [scriptPath], {
-    detached: true,
-    stdio: ["ignore", outFd, errFd],
-    windowsHide: true,
-  });
-  child.unref();
-  fs.closeSync(outFd);
-  fs.closeSync(errFd);
+  try {
+    const child = spawnProc(bashPath, [scriptPath], {
+      detached: true,
+      stdio: ["ignore", outFd, errFd],
+      windowsHide: true,
+    });
+    child.unref();
+  } finally {
+    fs.closeSync(outFd);
+    fs.closeSync(errFd);
+  }
 }
 
 async function windowsInstallService(): Promise<void> {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -170,15 +170,62 @@ async function runPowerShell(
 }
 
 async function windowsStopService(): Promise<void> {
-  // Stop the scheduled task (if running) + kill any leftover process
-  await runPowerShell(
-    `Stop-ScheduledTask -TaskName '${winTaskName}' -ErrorAction SilentlyContinue`,
+  // Stop the scheduled task (if running)
+  const taskResult = await runPowerShell(
+    `$t = Get-ScheduledTask -TaskName '${winTaskName}' -ErrorAction SilentlyContinue; ` +
+      `if ($t -and $t.State -eq 'Running') { Stop-ScheduledTask -TaskName '${winTaskName}'; Write-Output 'stopped_task' } ` +
+      `elseif ($t) { Write-Output 'task_not_running' } ` +
+      `else { Write-Output 'no_task' }`,
     { allowFailure: true },
   );
-  await runPowerShell(
-    `Get-Process -Name node -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowTitle -eq '' } | Stop-Process -Force -ErrorAction SilentlyContinue`,
+
+  // Kill bot process tree by port 3978
+  const pidResult = await runPowerShell(
+    `Get-NetTCPConnection -LocalPort 3978 -State Listen -ErrorAction SilentlyContinue | ` +
+      `Select-Object -First 1 -ExpandProperty OwningProcess`,
     { allowFailure: true },
   );
+  const botPid = pidResult.stdout.trim();
+
+  let portResult: { stdout: string } = { stdout: "no_process" };
+  if (botPid && /^\d+$/.test(botPid)) {
+    // Kill parent bash (run.sh) if present — this takes down bot + devtunnel together
+    await runPowerShell(
+      `$p = (Get-CimInstance Win32_Process -Filter "ProcessId=${botPid}" -ErrorAction SilentlyContinue).ParentProcessId; ` +
+        `if ($p) { $pp = Get-CimInstance Win32_Process -Filter "ProcessId=$p" -ErrorAction SilentlyContinue; ` +
+        `if ($pp -and $pp.Name -match 'bash') { Stop-Process -Id $p -Force -ErrorAction SilentlyContinue } }`,
+      { allowFailure: true },
+    );
+    // Kill bot process + its children (e.g. claude-agent-sdk subprocess)
+    await runPowerShell(
+      `Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | ` +
+        `Where-Object { $_.ParentProcessId -eq ${botPid} } | ` +
+        `ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }; ` +
+        `Stop-Process -Id ${botPid} -Force -ErrorAction SilentlyContinue`,
+      { allowFailure: true },
+    );
+    // Kill orphaned devtunnel host processes
+    await runPowerShell(
+      `Get-CimInstance Win32_Process -Filter "Name='devtunnel.exe'" -ErrorAction SilentlyContinue | ` +
+        `Where-Object { $_.CommandLine -match 'host' } | ` +
+        `ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`,
+      { allowFailure: true },
+    );
+    portResult = { stdout: `killed_pid_${botPid}` };
+  }
+
+  const taskOut = taskResult.stdout.trim();
+  const portOut = portResult.stdout.trim();
+
+  if (taskOut === "stopped_task") {
+    console.log("Scheduled task stopped.");
+  }
+  if (portOut.startsWith("killed_pid_")) {
+    const pid = portOut.replace("killed_pid_", "");
+    console.log(`Killed bot process (pid ${pid}).`);
+  } else if (taskOut === "no_task" && portOut === "no_process") {
+    console.log("Bot is not running.");
+  }
 }
 
 async function windowsStartBackground(): Promise<void> {
@@ -186,12 +233,28 @@ async function windowsStartBackground(): Promise<void> {
   const scriptPath = path
     .join(projectDir, "scripts", "run.sh")
     .replace(/\\/g, "/");
-  await runPowerShell(
-    `Start-Process -FilePath '${bashPath}' -ArgumentList '${scriptPath}' ` +
-      `-WindowStyle Hidden ` +
-      `-RedirectStandardOutput '${winLogPath}' ` +
-      `-RedirectStandardError '${winErrLogPath}'`,
-  );
+
+  // Truncate old logs so we only tail fresh output
+  for (const logPath of [winLogPath, winErrLogPath]) {
+    try {
+      fs.writeFileSync(logPath, "", "utf8");
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Use spawn with detached+unref to start background process without blocking
+  const { spawn: spawnProc } = await import("child_process");
+  const outFd = fs.openSync(winLogPath, "w");
+  const errFd = fs.openSync(winErrLogPath, "w");
+  const child = spawnProc(bashPath, [scriptPath], {
+    detached: true,
+    stdio: ["ignore", outFd, errFd],
+    windowsHide: true,
+  });
+  child.unref();
+  fs.closeSync(outFd);
+  fs.closeSync(errFd);
 }
 
 async function windowsInstallService(): Promise<void> {
@@ -256,43 +319,30 @@ async function windowsStartService(): Promise<void> {
 }
 
 async function windowsStatus(): Promise<void> {
+  // Check scheduled task
   const result = await runPowerShell(
     `$t = Get-ScheduledTask -TaskName '${winTaskName}' -ErrorAction SilentlyContinue; ` +
-      `if ($t) { ` +
-      `  $info = $t | Get-ScheduledTaskInfo; ` +
-      `  Write-Output "State: $($t.State)"; ` +
-      `  Write-Output "LastRun: $($info.LastRunTime)"; ` +
-      `  Write-Output "LastResult: $($info.LastTaskResult)"; ` +
-      `  Write-Output "NextRun: $($info.NextRunTime)" ` +
-      `} else { Write-Output 'NOT_INSTALLED' }`,
+      `if ($t) { Write-Output $t.State } else { Write-Output 'NOT_INSTALLED' }`,
     { allowFailure: true },
   );
-
-  const out = result.stdout.trim();
-  if (out === "NOT_INSTALLED") {
-    console.log("Service is not installed.");
-    return;
+  const taskState = result.stdout.trim();
+  if (taskState === "NOT_INSTALLED") {
+    console.log("Auto-start: not installed (run 'teams-bot install' to enable)");
+  } else {
+    console.log(`Auto-start: ${taskState.toLowerCase()}`);
   }
 
-  for (const line of out.split("\n")) {
-    const [key, ...rest] = line.split(": ");
-    const value = rest.join(": ").trim();
-    if (key === "State") {
-      console.log(
-        value === "Running"
-          ? "Service: RUNNING"
-          : `Service: ${value.toUpperCase()}`,
-      );
-    }
-  }
-
-  // Also check for any node process on port 3978
+  // Check if bot process is actually running on port 3978
   const portCheck = await runPowerShell(
-    `Get-NetTCPConnection -LocalPort 3978 -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1 OwningProcess`,
+    `$conn = Get-NetTCPConnection -LocalPort 3978 -State Listen -ErrorAction SilentlyContinue; ` +
+      `if ($conn) { Write-Output $conn.OwningProcess[0] } else { Write-Output 'NONE' }`,
     { allowFailure: true },
   );
-  if (portCheck.stdout.includes("OwningProcess")) {
-    console.log("Port 3978: IN USE");
+  const pid = portCheck.stdout.trim();
+  if (pid !== "NONE" && pid) {
+    console.log(`Process: running (pid ${pid})`);
+  } else {
+    console.log("Process: not running");
   }
 }
 

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -37,6 +37,8 @@ export interface ManagedSession {
   suggestionCardId?: string;
   /** Activity ID of the user's latest message (for reactions) */
   userActivityId?: string;
+  /** Pending reaction to send after stream closes (emoji response). */
+  pendingReaction?: string;
 }
 
 // ─── Persistence ───

--- a/src/session/state.ts
+++ b/src/session/state.ts
@@ -35,6 +35,8 @@ export interface ManagedSession {
   streamExpired?: boolean;
   /** Activity ID of the prompt suggestion card (auto-deleted on next message) */
   suggestionCardId?: string;
+  /** Activity ID of the user's latest message (for reactions) */
+  userActivityId?: string;
 }
 
 // ─── Persistence ───


### PR DESCRIPTION
## Summary

- **stop**: Kill bot precisely by port 3978 process tree instead of all headless node processes. Shows what was killed or "Bot is not running."
- **start**: Show key startup log lines (port, tunnel URL) on success; last 15 log lines + helpful hint on failure. Poll timeout increased 10s → 15s.
- **restart**: Reuse shared `pollAndShowLogs` — shows same feedback as start instead of bare "Restarted."
- **status**: Cleaner output: `Auto-start: ready/not installed` + `Process: running (pid X)/not running`
- **preflightCheck**: 10s timeout on `devtunnel` commands to prevent CLI hangs. `cmd /c` wrapper on Windows for PATH resolution.
- **windowsStartBackground**: Replace `Start-Process` PowerShell (which blocks in Git Bash) with Node `spawn({ detached, windowsHide })` + `unref()`

## Before

```
PS> teams-bot stop
                          ← (silent, killed all headless node processes)
PS> teams-bot start
Starting...
Bot is running.           ← (no log output)
PS> teams-bot restart
Restarted.                ← (no feedback on what happened)
```

## After

```
PS> teams-bot stop
Killed bot process (pid 29268).
PS> teams-bot start
Starting...
  [INFO] ExpressAdapter listening on port 3978 🚀
Bot is running.
PS> teams-bot restart
Killed bot process (pid 21508).
Building project...
Starting...
  [INFO] ExpressAdapter listening on port 3978 🚀
Bot is running.
PS> teams-bot status
Auto-start: ready
Process: running (pid 29268)
```

## Test plan

- [x] `teams-bot stop` — kills bot by port, shows pid
- [x] `teams-bot stop` when not running — shows "Bot is not running."
- [x] `teams-bot start` — starts bot, shows log output
- [x] `teams-bot start` when already running — shows "Bot is already running."
- [x] `teams-bot restart` — stops, builds, starts with full output
- [x] `teams-bot status` — shows auto-start + process state
- [x] `teams-bot health` — shows status + bot healthz + tunnel check (no deprecation warning)
- [x] macOS/Linux paths untouched — all changes gated on `win32`